### PR TITLE
Skip SFC implementations

### DIFF
--- a/pytwingrind/pytwingrind/prepare.py
+++ b/pytwingrind/pytwingrind/prepare.py
@@ -34,6 +34,10 @@ def add_guards(filepath, fb_name, hashes):
 
     nearly = 0
     ncallables = 0
+
+    if '<SFC>' in src:
+        logging.warning("Implementation is SFC in {}, skipping".format(fb_name))
+        return
     
     # add guards to functions
     functions = re.findall(r'<POU(.*?)Name="(.*?)"(.*?)FUNCTION (.*?)<ST><!\[CDATA\[(.*?)\]\]><\/ST>', src, re.S | re.M | re.UNICODE)


### PR DESCRIPTION
If a project has one or more programs implemented in SFC the regex go into a long search loops  given that SFC files can be 30k+ lines. The prepare function just holds forever.

This just adds a check and skip for those types of files.